### PR TITLE
Metainfo updated and ready for automation

### DIFF
--- a/com.icons8.Lunacy.metainfo.xml
+++ b/com.icons8.Lunacy.metainfo.xml
@@ -22,15 +22,8 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="8.4.1" date="2022-03-28">
-      <description>
-        <ul>
-          <li>Redesigned context menu</li>
-          <li>Track viewport mode</li>
-          <li>Setting hyperlinks to layers</li>
-          <li>Improvements</li>
-        </ul>
-      </description>
-    </release>
+    <release version="8.5.2" date="2022-06-08"/>  
+    <release version="8.4.1" date="2022-03-28"/>
+    <release version="8.3.0" date="2022-03-02"/>
   </releases> 
 </component>

--- a/com.icons8.Lunacy.yml
+++ b/com.icons8.Lunacy.yml
@@ -50,6 +50,7 @@ modules:
           type: html
           url: https://docs.icons8.com/release-notes
           pattern: (https://lun-eu.icons8.com/s/setup/Lunacy_([0-9.]+).deb)
+          is-main-source: true
 
       - type: script
         dest-filename: apply_extra


### PR DESCRIPTION
Added release 8.5.2 in metainfo. Currently it is showing 8.4.1 even though it is using 8.5.2

Removed release notes.
This is removed so we can automate most of this on new releases.

Added `is-main-source: true` to auto include release numbers in metainfo.

