### PR TITLE
Changed the pattern to be more generic.

### DIFF
--- a/com.icons8.Lunacy.yml
+++ b/com.icons8.Lunacy.yml
@@ -50,7 +50,7 @@ modules:
         x-checker-data:
           type: html
           url: https://docs.icons8.com/release-notes
-          pattern: (https://lun-eu.icons8.com/s/setup/Lunacy_([0-9.]+).deb)
+          pattern: (https://\S+/setup/Lunacy_([0-9.]+).deb)
           is-main-source: true
 
       - type: script


### PR DESCRIPTION
Lunacy seem to have changed their CDN and now the pattern does not mach anymore.

Updated the pattern.

This should kick off the auto pull request to get latest version of Lunacy again.