### PR TITLE
Update runtimes

### DIFF
--- a/com.icons8.Lunacy.yml
+++ b/com.icons8.Lunacy.yml
@@ -1,6 +1,6 @@
 app-id: com.icons8.Lunacy
 runtime: org.freedesktop.Platform
-runtime-version: 21.08
+runtime-version: 23.08
 sdk: org.freedesktop.Sdk
 command: lunacy
 build-options:


### PR DESCRIPTION
Update org.freedesktop.Platform to 23.08, 21.08 is EOL.