### PR TITLE
Fix Appstream & Update to Lunacy 9.5.0

### DIFF
--- a/com.icons8.Lunacy.metainfo.xml
+++ b/com.icons8.Lunacy.metainfo.xml
@@ -74,6 +74,14 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="9.5.0" date="2024-03-19">
+      <description>
+        <p>FREE format</p>
+        <p>The default file format in Lunacy is now <code>.free</code>, which is almost fully compatible with the features from the Figma and Sketch formats. We designed <code>.free</code> to address the issues available in <code>.sketch</code> when it comes to very large design files.</p>
+        <p>Lunacy still supports <code>.sketch</code> like no other app, except Sketch itself. But for better experience with Lunacy, we recommend using <code>.free</code>.</p>
+        <p>You can easily convert between the formats using the "Save as" option.</p>
+      </description>
+    </release>
     <release version="9.4.2.5022" date="2024-02-08"/>
     <release version="9.4.1" date="2024-02-03"/>
     <release version="9.3.3" date="2023-12-28"/>

--- a/com.icons8.Lunacy.metainfo.xml
+++ b/com.icons8.Lunacy.metainfo.xml
@@ -3,7 +3,6 @@
   <id>com.icons8.Lunacy</id>
   <name>Lunacy</name>
   <summary>Free graphic design tool for UX/UI</summary>
-  <developer_name translatable="no">Icons8</developer_name>
   <developer id="icons8.com">
     <name translatable="no">Icons8</name>
   </developer>
@@ -26,26 +25,51 @@
     </ul>
     <p>And much more!</p>
     <p>Don’t forget to join our growing designer community!</p>
-    <ul>
-      <li>Our X: https://twitter.com/Icons8_Lunacy</li>
-      <li>Request a feature: https://lunatics.icons8.com/discussions</li>
-      <li>Report a bug: https://community.icons8.com/c/lunacy/7</li>
-    </ul>
   </description>
   <url type="homepage">https://icons8.com/lunacy</url>
+  <url type="bugtracker">https://community.icons8.com/c/lunacy/7</url>
+  <url type="contact">https://lunacy.docs.icons8.com/contact/</url>
   <launchable type="desktop-id">com.icons8.Lunacy.desktop</launchable>
   <screenshots>
     <screenshot type="default">
       <image>https://cloud.icons8.com/s/FXdw54epZrmy8JP/download/Build%20projects%20beyond%20imagination.png</image>
+      <caption>Build Projects Beyond Imagination</caption>
+    </screenshot>
+    <screenshot>
       <image>https://cloud.icons8.com/s/gHqyN8ScxjbWntq/download/Collaborate%20in%20real-time.png</image>
+      <caption>Collaborate in real-time</caption>
+    </screenshot>
+    <screenshot>
       <image>https://cloud.icons8.com/s/er2qHAQnsd6XqQZ/download/Design%20faster%20with%20auto%20layout.png</image>
+      <caption>Design faster with auto layout</caption>
+    </screenshot>
+    <screenshot>
       <image>https://cloud.icons8.com/s/JFMY7fyF6qX7ppt/download/Generate%20content%20and%20enhance%20images.png</image>
+      <caption>Generate content and enhance images</caption>
+    </screenshot>
+    <screenshot>
       <image>https://cloud.icons8.com/s/Eq8qYWZmLf3QsTm/download/Graphic%20design%20reimagined.png</image>
+      <caption>Graphic Design reimagined</caption>
+    </screenshot>
+    <screenshot>
       <image>https://cloud.icons8.com/s/SY7SNm2tZbYsmMH/download/Import%20your%20latest%20designs%20from%20Figma%20and%20work%20in%20other%20formats.png</image>
+      <caption>Import your latest designs from Figma and work in other formats</caption>
+    </screenshot>
+    <screenshot>
       <image>https://cloud.icons8.com/s/ssKAd2q5BscGtb7/download/No%20need%20to%20stay%20online.png</image>
+      <caption>No need to stay online</caption>
+    </screenshot>
+    <screenshot>
       <image>https://cloud.icons8.com/s/dJbLgarE2Pk2rgM/download/Prototype%20to%20your%20heart%E2%80%99s%20content!.png</image>
+      <caption>Prototype to your heart's content</caption>
+    </screenshot>
+    <screenshot>
       <image>https://cloud.icons8.com/s/M4XN4qMrS4kcCEg/download/Store%20your%20files%20in%20the%20cloud%20and%20access%20them%20anywhere.png</image>
+      <caption>Store your files in the cloud and access them anywhere</caption>
+    </screenshot>
+    <screenshot>
       <image>https://cloud.icons8.com/s/3XW8QxeeiHFpNaW/download/Use%201.5%20million%20icons,%20illustrations,%20and%20photos.png</image>
+      <caption>Use 1.5 million icons, illustrations, and photos</caption>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>

--- a/com.icons8.Lunacy.yml
+++ b/com.icons8.Lunacy.yml
@@ -41,9 +41,9 @@ modules:
     sources:
       - type: extra-data
         filename: Lunacy.deb
-        url: https://lcdn.icons8.com/setup/Lunacy_9.4.2.5022.deb
-        sha256: ebd08ed523dd3be261007fc6fc38a1c870ee79038b69a2427f7d8c8c173bee3e
-        size: 77969632
+        url: https://lcdn.icons8.com/setup/Lunacy_9.5.0.deb
+        sha256: 746db12e8a91409b1a47bbf4d22378e863f88c1f1656bc5aca7d824902c25254
+        size: 78316592
         only-arches:
           - x86_64
         x-checker-data:


### PR DESCRIPTION
Appstream metainfo was broken, breaking auto-merge builds in turn https://github.com/flathub/com.icons8.Lunacy/pull/54#issuecomment-2014271463
Fixes that and updates to the latest release