### PR TITLE
Fixes the issue where users' application settings are not saved

### DIFF
--- a/com.icons8.Lunacy.yml
+++ b/com.icons8.Lunacy.yml
@@ -14,6 +14,8 @@ finish-args:
   - --socket=cups
   - --socket=pulseaudio
   - --socket=x11
+  # It is needed for the correct operation of settings saving under Wayland.
+  - --filesystem=home
   - --filesystem=xdg-download
   - --filesystem=xdg-documents
   - --filesystem=xdg-run/gvfs


### PR DESCRIPTION
We had several reports from users that every time the application is launched, it behaves as if it has just been installed — application settings are not saved, fonts are not cached locally, and logs are not written. While these issues are inconvenient, they can still be tolerated. However, Lunacy has a feature where work progress is automatically saved, allowing users to continue from where they left off after reopening the application. Unfortunately, this progress was not being saved.

![image](https://github.com/user-attachments/assets/a9cef8f7-d61a-40e2-b7ec-615fa2f777c5)


For a long time, we were unable to reproduce this issue. Yesterday, as a Lunacy developer, I switched to a Wayland session and was able to fully reproduce this behavior. Further investigation revealed that, for some reason, .NET fails to access the path `~/.var/app/com.icons8.Lunacy/.local/share/` when generating the directory for writing local data using `Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)`.

Granting permissions to the home directory for the Flatpak application via Flatseal completely resolves this issue, allowing Lunacy to create the necessary file structure in the user's home directory under `~/.local/share/Icons8/Lunacy/`.